### PR TITLE
only add scroll buttons to pages with multiple sections

### DIFF
--- a/js/compose.js
+++ b/js/compose.js
@@ -6,12 +6,14 @@ import { HideHR, GetUniqueProjectTags } from "/js/utils.js";
 
 function ComposeSecondSectionScrollButton() {
     let numSections = document.querySelectorAll("section").length;
+    // only add if there is more than one section (ie. something else to scroll to)
     if(numSections > 1)
         document.querySelector("section:first-of-type").append(BuildLocalScrollButton());
 }
 
 function ComposeBackToTopButton() {
     let numSections = document.querySelectorAll("section").length;
+    // only add if there is more than one section (ie. something else to scroll to)
     if(numSections > 1) {
         let lastSection = document.querySelector("section:last-of-type > .container");
         let row = BuildCentreRow();

--- a/js/compose.js
+++ b/js/compose.js
@@ -5,14 +5,15 @@ import { HOME_EXCLUDE_LIST, PROJECTS_LIST } from "/js/constants.js";
 import { HideHR, GetUniqueProjectTags } from "/js/utils.js";
 
 function ComposeSecondSectionScrollButton() {
-    let firstSection = document.querySelector("section:first-of-type");
-    if(firstSection != null)
-        firstSection.append(BuildLocalScrollButton());
+    let numSections = document.querySelectorAll("section").length;
+    if(numSections > 1)
+        document.querySelector("section:first-of-type").append(BuildLocalScrollButton());
 }
 
 function ComposeBackToTopButton() {
-    let lastSection = document.querySelector("section:last-of-type > .container");
-    if(lastSection != null) {
+    let numSections = document.querySelectorAll("section").length;
+    if(numSections > 1) {
+        let lastSection = document.querySelector("section:last-of-type > .container");
         let row = BuildCentreRow();
         row.append(BuildBackToTopButton());
         lastSection.append(row);


### PR DESCRIPTION
accidentally removed this feature
needs to be in place as some pages only have a single section hence there is nothing to scroll to